### PR TITLE
Fix sentence for verbose description.

### DIFF
--- a/Generator/init.php
+++ b/Generator/init.php
@@ -19,7 +19,7 @@ $clio = new Clio();
 // Set info on shell for the script
 $cmd->setHelp( 'WPBP Generator enable you to get a customized version (based on your needs) of WordPress Plugin Boilerplate Powered.' );
 $cmd->option( 'dev' )->describedAs( 'Download from the master branch (the development version).' )->boolean();
-$cmd->option( 'verbose' )->describedAs( 'Verbose output. Beucase can be helpful for debugging!' )->boolean();
+$cmd->option( 'verbose' )->describedAs( 'Verbose output. Because this can be helpful for debugging!' )->boolean();
 $cmd->option( 'json' )->describedAs( 'Generate a wpbp.json file in the current folder.' )->boolean();
 $cmd->option( 'no-download' )->describedAs( 'Do you want to execute composer and npm manually? This is your flag!' )->boolean();
 $clio->styleLine( "(>'-')> WPBP Code Generator by Mte90", $white );


### PR DESCRIPTION
Add more description :p

```patch
-$cmd->option( 'verbose' )->describedAs( 'Verbose output. Beucase can be helpful for debugging!' )->boolean();
+$cmd->option( 'verbose' )->describedAs( 'Verbose output. Because this can be helpful for debugging!' )->boolean();
```