### PR TITLE
Make white color blue to fix both white/black terminals.

### DIFF
--- a/Generator/functions.php
+++ b/Generator/functions.php
@@ -3,6 +3,41 @@
 use LightnCandy\LightnCandy;
 use LightnCandy\Runtime;
 
+use Clio\Style\Style;
+
+function setTheme() {
+	global $cmd;
+
+	if ( $cmd[ 'dark' ] ) {
+		setDarkTheme();
+	}
+	else {
+		setLightTheme();
+	}
+}
+
+function setDarkTheme() {
+	global $white, $yellow, $red;
+
+	$white = new Style();
+	$white->setTextColor( 'white' )->setBold( true )->setUnderscore();
+	$red = new Style();
+	$red->setTextColor( 'red' )->setBold( true );
+	$yellow = new Style();
+	$yellow->setTextColor( 'yellow' )->setBold( true );
+}
+
+function setLightTheme() {
+	global $white, $yellow, $red;
+
+	$white = new Style();
+	$white->setTextColor( 'black' )->setBold( true )->setUnderscore();
+	$red = new Style();
+	$red->setTextColor( 'red' )->setBold( true );
+	$yellow = new Style();
+	$yellow->setTextColor( 'yellow' )->setBold( true );
+}
+
 /**
  * Print the label if the shell is executed as verbose
  *

--- a/Generator/init.php
+++ b/Generator/init.php
@@ -9,19 +9,17 @@ use Clio\Style\Style;
 
 // Initiate Libraries
 $cmd = new Commando\Command();
-$white = new Style();
-$white->setTextColor( 'blue' )->setBold( true )->setUnderscore();
-$red = new Style();
-$red->setTextColor( 'red' )->setBold( true );
-$yellow = new Style();
-$yellow->setTextColor( 'yellow' )->setBold( true );
 $clio = new Clio();
 // Set info on shell for the script
 $cmd->setHelp( 'WPBP Generator enable you to get a customized version (based on your needs) of WordPress Plugin Boilerplate Powered.' );
+$cmd->option( 'dark' )->describedAs( 'Use a dark theme console output.' )->boolean();
 $cmd->option( 'dev' )->describedAs( 'Download from the master branch (the development version).' )->boolean();
 $cmd->option( 'verbose' )->describedAs( 'Verbose output. Because this can be helpful for debugging!' )->boolean();
 $cmd->option( 'json' )->describedAs( 'Generate a wpbp.json file in the current folder.' )->boolean();
 $cmd->option( 'no-download' )->describedAs( 'Do you want to execute composer and npm manually? This is your flag!' )->boolean();
+
+setTheme();
+
 $clio->styleLine( "(>'-')> WPBP Code Generator by Mte90", $white );
 echo PHP_EOL;
 // Generate the wpbp.json file

--- a/Generator/init.php
+++ b/Generator/init.php
@@ -10,7 +10,7 @@ use Clio\Style\Style;
 // Initiate Libraries
 $cmd = new Commando\Command();
 $white = new Style();
-$white->setTextColor( 'white' )->setBold( true )->setUnderscore();
+$white->setTextColor( 'blue' )->setBold( true )->setUnderscore();
 $red = new Style();
 $red->setTextColor( 'red' )->setBold( true );
 $yellow = new Style();


### PR DESCRIPTION
This is just a proposal for another color. In which we learned `$white` should probably be named semantic. I just changed the color and not the name.

I guess we should change the vars

```php
$white -> $info
$yellow -> $notice
$red -> $error
```

What do you think?