### PR TITLE
Use execution operator instead of string comparison

### DIFF
--- a/bin/wpbp-generator
+++ b/bin/wpbp-generator
@@ -19,13 +19,13 @@ if ( !$found ) {
   );
 }
 
-if ( !'which npm' ) {
+if ( !`which npm` ) {
   die(
 	    'You need to install NPM!' . PHP_EOL
   );
 }
 
-if ( !'which git' ) {
+if ( !`which git` ) {
   die(
 	    'You need to install Git!' . PHP_EOL
   );

--- a/bin/wpbp-generator
+++ b/bin/wpbp-generator
@@ -19,6 +19,7 @@ if ( !$found ) {
   );
 }
 
+// Backtick operator is used to execute the command and get the result: http://php.net/manual/en/language.operators.execution.php
 if ( !`which npm` ) {
   die(
 	    'You need to install NPM!' . PHP_EOL


### PR DESCRIPTION
`if ( !'which npm' ) {` just checks if the string `'which npm'` is falsey, which it never is. I guess you meant to use the backtick, which execute the given command.