### PR TITLE
Check whether the php-yaml extension is loaded before use it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     "zordius/lightncandy": "^1.2",
     "nategood/commando": "0.4.0",
     "1happyplace/clio": "2.3.1",
-    "perchten/rmrdir": "1.*"
+    "perchten/rmrdir": "1.*",
+    "ext-json": "*",
+    "ext-yaml": "*"
   },
   "bin": [
     "bin/wpbp-generator"

--- a/generator/tools.php
+++ b/generator/tools.php
@@ -32,31 +32,37 @@ function git_init() {
  * @global array $config
  * @global object $clio
  * @global object $info
+ *
+ * @return void
  */
 function grumphp() {
-    global $config, $clio, $info;
+    global $config, $clio, $info, $error;
     if ( file_exists( getcwd() . DIRECTORY_SEPARATOR . WPBP_PLUGIN_SLUG . DIRECTORY_SEPARATOR .'grumphp.yml' ) ) {
+        if (! extension_loaded('yaml')) {
+            $clio->clear()->style( $error )->display( "😡 Yaml php extension not installed!" )->newLine();
+            return;
+        }
         $grumphp = yaml_parse_file ( getcwd() . DIRECTORY_SEPARATOR . WPBP_PLUGIN_SLUG . DIRECTORY_SEPARATOR . 'grumphp.yml' );
         if ( is_empty_or_false( $config[ 'phpstan' ] ) ) {
             unset( $grumphp[ 'parameters' ][ 'tasks' ][ 'phpstan' ] );
             $clio->clear()->style( $info )->display( "😀 PHPStan removed from GrumPHP" )->newLine();
         }
-        
+
         if ( is_empty_or_false( $config[ 'unit-test' ] ) ) {
             unset( $grumphp[ 'parameters' ][ 'tasks' ][ 'codeception' ] );
             $clio->clear()->style( $info )->display( "😀 Codeception removed from GrumPHP" )->newLine();
         }
-        
+
         if ( is_empty_or_false( $config[ 'phpcs' ] ) ) {
             unset( $grumphp[ 'parameters' ][ 'tasks' ][ 'phpcs' ] );
             $clio->clear()->style( $info )->display( "😀 PHPCS removed from GrumPHP" )->newLine();
         }
-        
+
         if ( is_empty_or_false( $config[ 'phpmd' ] ) ) {
             unset( $grumphp[ 'parameters' ][ 'tasks' ][ 'phpmd' ] );
             $clio->clear()->style( $info )->display( "😀 PHPMD removed from GrumPHP" )->newLine();
         }
-        
+
         yaml_emit_file( getcwd() . DIRECTORY_SEPARATOR . WPBP_PLUGIN_SLUG . DIRECTORY_SEPARATOR . 'grumphp.yml', $grumphp );
     }
 }

--- a/generator/wpbp.php
+++ b/generator/wpbp.php
@@ -25,8 +25,6 @@ function create_wpbp_json() {
         
         $clio->clear()->style( $info )->display( "😀 wpbp.json generated" )->newLine()->clear();
         exit();
-        
-        return;
     }
     
     if ( !file_exists( getcwd() . DIRECTORY_SEPARATOR . 'wpbp.json' ) ) {


### PR DESCRIPTION
Added check to ensure "php-yaml" extension is loaded before usage.

I experienced a crash while running the generator on my local machine using WSL. The root cause was that I had not installed the "php-yaml" extension, which the generator relied on. To prevent such issues in the future, I have included a check at the beginning of the code to ensure that the extension is loaded before proceeding with any YAML parsing.

This way, we can guarantee that the generator won't encounter a fatal error due to a missing extension.

Thanks for reviewing!